### PR TITLE
fix: config.get处停止热键配置与generate_default_config中不同

### DIFF
--- a/Traffick_LTS/Aventurine_Traffick.py
+++ b/Traffick_LTS/Aventurine_Traffick.py
@@ -108,7 +108,7 @@ def generate_default_config():
         ],
         "similarity_threshold": 0.8,
         "drag_set_B": {"from": {"x": 2100, "y": 1600}, "to": {"x": 2900, "y": 1600}, "duration": 0.15},
-        "hotkey_stop": "ctrl+shift+z",
+        "hotkey_stop": "ctrl+shift+x",
         "drag_poll_interval": 0.4,
         "max_rounds": 30,
         "drag_max_wait": 3.5


### PR DESCRIPTION
Change default hotkey_stop from ctrl+shift+z to ctrl+shift+x for consistency with config.get fallback value

fix #2 

保持生成的默认配置中热键与代码中一致